### PR TITLE
Dev config cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@ Release (*.*)/
 *.sdf
 *.suo
 ipch/
-*.VC.db
-*.VC.VC.opendb
+*.VC.*
 
 xcuserdata/
 

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,61 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "/usr/include",
+                "/usr/local/include",
+                "${workspaceRoot}/Hello World/src",
+                "${workspaceRoot}/ThirdParty/include/ruby/2.2/mac"
+            ],
+            "defines": [],
+            "intelliSenseMode": "clang-x64",
+            "browse": {
+                "path": [
+                    "/usr/include",
+                    "/usr/local/include",
+                    "${workspaceRoot}/Hello World/src"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "macFrameworkPath": [
+                "/System/Library/Frameworks",
+                "/Library/Frameworks"
+            ]
+        },
+        {
+            "name": "Win32",
+            "includePath": [
+                "C:/Program Files (x86)/Microsoft Visual Studio/2017/Professional/VC/Tools/MSVC/14.11.25503/include/*",
+                "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um",
+                "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt",
+                "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared",
+                "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt",
+                "${workspaceRoot}/Hello World/src",
+                "${workspaceRoot}/ThirdParty/include/ruby/2.0/win32",
+                "${workspaceRoot}/ThirdParty/include/ruby/2.0/win32/i386-mswin32_100"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE"
+            ],
+            "intelliSenseMode": "msvc-x64",
+            "browse": {
+                "path": [
+                    "C:/Program Files (x86)/Microsoft Visual Studio/2017/Professional/VC/Tools/MSVC/14.11.25503/include/*",
+                    "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um",
+                    "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt",
+                    "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared",
+                    "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt",
+                    "${workspaceRoot}/Hello World/src",
+                    "${workspaceRoot}/ThirdParty/include/ruby/2.2/win32_x64",
+                    "${workspaceRoot}/ThirdParty/include/ruby/2.2/win32_x64/x64-mswin64_140"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            }
+        }
+    ],
+    "version": 3
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,7 +1,7 @@
 {
     "configurations": [
         {
-            "name": "Mac",
+            "name": "Mac - Ruby 2.2",
             "includePath": [
                 "/usr/include",
                 "/usr/local/include",
@@ -25,7 +25,7 @@
             ]
         },
         {
-            "name": "Win32",
+            "name": "Windows x64 - Ruby 2.2",
             "includePath": [
                 "C:/Program Files (x86)/Microsoft Visual Studio/2017/Professional/VC/Tools/MSVC/14.11.25503/include/*",
                 "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um",
@@ -33,8 +33,8 @@
                 "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared",
                 "C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt",
                 "${workspaceRoot}/Hello World/src",
-                "${workspaceRoot}/ThirdParty/include/ruby/2.0/win32",
-                "${workspaceRoot}/ThirdParty/include/ruby/2.0/win32/i386-mswin32_100"
+                "${workspaceRoot}/ThirdParty/include/ruby/2.2/win32_x64",
+                "${workspaceRoot}/ThirdParty/include/ruby/2.2/win32_x64/x64-mswin64_140"
             ],
             "defines": [
                 "_DEBUG",

--- a/Hello World/Hello World.vcxproj
+++ b/Hello World/Hello World.vcxproj
@@ -55,6 +55,7 @@
     <RootNamespace>SUEX_HelloWorld</RootNamespace>
     <Keyword>MFCDLLProj</Keyword>
     <ProjectName>SUEX_HelloWorld</ProjectName>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (2.0)|Win32'" Label="Configuration">
@@ -132,62 +133,62 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (1.8)|Win32'">
     <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2013\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (1.8)|x64'">
     <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2013\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (1.8)|Win32'">
     <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2013\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (1.8)|x64'">
     <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2013\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (2.0)|Win32'">
     <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2015\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (2.2)|Win32'">
-    <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2015\SketchUp.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2017\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (2.0)|x64'">
-    <LocalDebuggerCommand>$(ProgramW6432)\SketchUp\SketchUp 2015\SketchUp.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommand>$(ProgramW6432)\SketchUp\SketchUp 2016\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(PlatformTarget)\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (2.2)|x64'">
-    <LocalDebuggerCommand>$(ProgramW6432)\SketchUp\SketchUp 2015\SketchUp.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommand>$(ProgramW6432)\SketchUp\SketchUp 2017\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(PlatformTarget)\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (2.0)|Win32'">
     <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2015\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (2.2)|Win32'">
-    <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2015\SketchUp.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommand>$(ProgramFiles)\SketchUp\SketchUp 2017\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (2.0)|x64'">
-    <LocalDebuggerCommand>$(ProgramW6432)\SketchUp\SketchUp 2015\SketchUp.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommand>$(ProgramW6432)\SketchUp\SketchUp 2016\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(PlatformTarget)\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (2.2)|x64'">
-    <LocalDebuggerCommand>$(ProgramW6432)\SketchUp\SketchUp 2015\SketchUp.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommand>$(ProgramW6432)\SketchUp\SketchUp 2017\SketchUp.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\$(PlatformTarget)\$(Configuration).rb"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-RubyStartup "$(SolutionDir)Ruby\launch_sketchup.rb" -RubyStartupArg "$(Configuration):$(PlatformTarget)"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -240,13 +241,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (2.0)|x64'">
     <LinkIncremental>true</LinkIncremental>
     <TargetExt>.so</TargetExt>
-    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (2.2)|x64'">
     <LinkIncremental>true</LinkIncremental>
     <TargetExt>.so</TargetExt>
-    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (1.8)|Win32'">
@@ -256,7 +257,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (1.8)|x64'">
     <LinkIncremental>true</LinkIncremental>
     <TargetExt>.so</TargetExt>
-    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (2.0)|Win32'">
@@ -270,13 +271,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (2.0)|x64'">
     <LinkIncremental>false</LinkIncremental>
     <TargetExt>.so</TargetExt>
-    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (2.2)|x64'">
     <LinkIncremental>false</LinkIncremental>
     <TargetExt>.so</TargetExt>
-    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (1.8)|Win32'">
@@ -286,7 +287,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (1.8)|x64'">
     <LinkIncremental>false</LinkIncremental>
     <TargetExt>.so</TargetExt>
-    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug (2.0)|Win32'">

--- a/Hello World/src/RubyUtils/RubyLib.h
+++ b/Hello World/src/RubyUtils/RubyLib.h
@@ -1,13 +1,25 @@
 #ifndef SU_UTILS_RUBYLIB_H_
 #define SU_UTILS_RUBYLIB_H_
 
-// Needed for VS2015.
-// TODO(thomthom): Not sure if this apply for Ruby 2.0 build.
-#if _MSC_VER >= 1900
 
-// Ruby was configured for Visual Studio 2010. These macros are needed to
-// prevent compiler errors with Visual Studio 2013. This relate to release
-// builds which are compiled with MT.
+// Disable all warnings.
+// http://stackoverflow.com/a/2541990/486990
+#pragma warning(push, 0)
+
+// Must disable the min/max macros defined by windows.h to avoid conflict with
+// std::max and std:min. Ruby includes windows.h so it must be disabled here.
+// http://stackoverflow.com/a/2789509/486990
+#define NOMINMAX
+
+// Ruby in SketchUp was configured with /MD and the headers reflect that.
+// And from Ruby version to Ruby version the configuration needs to be slightly
+// different. These macros smooth over this and should allow the project
+// to be built with newer Visual Studio runtimes as well as /MT.
+
+#if _MT
+
+// Visual Studio 2013
+#if _MSC_VER >= 1800
 
 // Ruby 2.0
 #define HAVE_ACOSH 1
@@ -15,17 +27,34 @@
 #define HAVE_ERF 1
 #define HAVE_TGAMMA 1
 #define HAVE_ROUND 1
-#define HAVE_STRUCT_TIMESPEC 1
 
 // Ruby 2.2
-// TODO(thomthom): #ifdef this out to only apply when building Ruby 2.2?
 #define HAVE_NEXTAFTER 1
 
-#endif
+#endif // VS 2013
+
+// Visual Studio 2015
+#if _MSC_VER >= 1900
+
+#define HAVE_STRUCT_TIMESPEC 1
+
+#endif // VS2015
+
+#endif // _MT
+
+// For some reason Xcode will flag warnings (which are treated as errors) in
+// the Ruby headers. This works around that.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
 
 #include <ruby.h>
+// ruby/encoding.h only existed from Ruby 2.0.
 #ifdef HAVE_RUBY_ENCODING_H
 #include <ruby/encoding.h>
 #endif
+
+#pragma clang diagnostic pop
+
+#pragma warning (pop)
 
 #endif // SU_UTILS_RUBYLIB_H_

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Notes on how the solution is set up:
 * The project name must match the name of the `Init_*()` function. Example: If the project name is HelloWorld the init function must be named `Init_HelloWorld`.
 * The init function must be exported in the .def file - named the same as the project.
 
+#### Debugging
+
+The Visual Studio project is set up to launch SketchUp and then load the built
+Ruby C Extension so you can debug your code. The various build configuration
+is set up to launch different SketchUp versions. Refer to the project
+configuration and make your adjustments as needed:
+
+`SUEX_HelloWorld > Right Click > Configuration Properties > Debugging`
+
 ### Xcode 8
 
 Xcode project is set up to build targets all the way back to Ruby 1.8.

--- a/Ruby/Debug (1.8).rb
+++ b/Ruby/Debug (1.8).rb
@@ -1,2 +1,0 @@
-RELEASE = File.basename(__FILE__, '.*').freeze
-require File.join( File.dirname(__FILE__), 'setup_environment.rb' )

--- a/Ruby/Debug (2.0).rb
+++ b/Ruby/Debug (2.0).rb
@@ -1,2 +1,0 @@
-RELEASE = File.basename(__FILE__, '.*').freeze
-require File.join( File.dirname(__FILE__), 'setup_environment.rb' )

--- a/Ruby/Release (1.8).rb
+++ b/Ruby/Release (1.8).rb
@@ -1,2 +1,0 @@
-RELEASE = File.basename(__FILE__, '.*').freeze
-require File.join( File.dirname(__FILE__), 'setup_environment.rb' )

--- a/Ruby/Release (2.0).rb
+++ b/Ruby/Release (2.0).rb
@@ -1,2 +1,0 @@
-RELEASE = File.basename(__FILE__, '.*').freeze
-require File.join( File.dirname(__FILE__), 'setup_environment.rb' )

--- a/Ruby/launch_sketchup.rb
+++ b/Ruby/launch_sketchup.rb
@@ -1,19 +1,29 @@
 # This file should be required by a file that has defined `RELEASE` to be the
 # name of the build folder where the binaries are located.
 
+configuration, platform = ARGV[0].split(':')
+
 if SKETCHUP_CONSOLE.respond_to?(:show)
   SKETCHUP_CONSOLE.show
 else
   Sketchup.send_action("showRubyPanel:")
 end
 
-prostatus = Sketchup.is_pro? ? "Pro" : ""
-puts "SketchUp #{prostatus} #{Sketchup.version}"
-puts "Loading '#{RELEASE}' build..."
+pro_status = Sketchup.is_pro? ? "Pro" : ""
+puts "SketchUp #{pro_status} #{Sketchup.version}"
+puts "Loading '#{configuration}' (#{platform}) build..."
 
 ruby_path = File.dirname(__FILE__)
 project_path = File.expand_path( File.join(ruby_path, '..') )
-binary_path = File.join(project_path, RELEASE)
+if platform == 'x64'
+  binary_path = File.join(project_path, configuration, platform)
+else
+  binary_path = File.join(project_path, configuration)
+end
+
+puts ruby_path
+puts project_path
+puts binary_path
 
 pattern = File.join(binary_path, "*.{so,bundle}")
 Dir.glob(pattern).each { |library|

--- a/Ruby/x64/Debug (2.0).rb
+++ b/Ruby/x64/Debug (2.0).rb
@@ -1,2 +1,0 @@
-RELEASE = File.join(File.basename(__FILE__, '.*'), "x64").freeze
-require File.join( File.dirname(__FILE__), "..", 'setup_environment.rb' )

--- a/Ruby/x64/Release (2.0).rb
+++ b/Ruby/x64/Release (2.0).rb
@@ -1,2 +1,0 @@
-RELEASE = File.join(File.basename(__FILE__, '.*'), "x64").freeze
-require File.join( File.dirname(__FILE__), "..", 'setup_environment.rb' )


### PR DESCRIPTION
Getting rid of a bunch of ruby files that was mainly identical in content. This should make it easier to add new configs in the future.

Other things we should do (in other CLs): 
* Set up Xcode project to also launch SketchUp
* Sanitize the VS project config. Create a "common" property sheet that can be shared between all the Ruby configs. Then we only need to adjust the differences for each Ruby build.